### PR TITLE
Improved error logging

### DIFF
--- a/src/Middleware/ExceptionMiddleware.php
+++ b/src/Middleware/ExceptionMiddleware.php
@@ -42,6 +42,7 @@ class ExceptionMiddleware implements MiddlewareInterface
     /**
      * @param HandlerInterface $handler
      * @param bool $isProduction
+     * @param int $verbosity
      */
     public function __construct(?HandlerInterface $handler = null, bool $isProduction = false, int $verbosity = self::VERBOSITY_MIN)
     {
@@ -316,6 +317,12 @@ class ExceptionMiddleware implements MiddlewareInterface
         return $this->handler;
     }
 
+    /**
+     * Get URL query params as string or array depending on the verbosity level set
+     *
+     * @param Url $url
+     * @return array|string
+     */
     private function getQueryParametersFromUrl(Url $url)
     {
         return $this->verbosity > self::VERBOSITY_MIN ? $url->getAllQueryParams() : json_encode($url->getAllQueryParams());

--- a/src/Middleware/ExceptionMiddleware.php
+++ b/src/Middleware/ExceptionMiddleware.php
@@ -278,9 +278,7 @@ class ExceptionMiddleware implements MiddlewareInterface
                 'raw'   => $currentUrl->__toString(),
                 'host'  => $currentUrl->getHost(),
                 'path'  => $currentUrl->getPath(),
-                'query' => $this->verbosity > self::VERBOSITY_MIN
-                        ? json_encode($currentUrl->getAllQueryParams())
-                        : $currentUrl->getAllQueryParams()
+                'query' => $this->getQueryParametersFromUrl($currentUrl),
             ],
             'timestamp'   => (new Moment())->format(),
         ];
@@ -293,9 +291,7 @@ class ExceptionMiddleware implements MiddlewareInterface
                 'raw'   => $refererUrl->__toString(),
                 'host'  => $refererUrl->getHost(),
                 'path'  => $refererUrl->getPath(),
-                'query' => $this->verbosity > self::VERBOSITY_MIN
-                        ? json_encode($refererUrl->getAllQueryParams())
-                        : $refererUrl->getAllQueryParams(),
+                'query' => $this->getQueryParametersFromUrl($refererUrl),
             ];
         }
 
@@ -318,5 +314,10 @@ class ExceptionMiddleware implements MiddlewareInterface
     private function getHandler(): HandlerInterface
     {
         return $this->handler;
+    }
+
+    private function getQueryParametersFromUrl(Url $url)
+    {
+        return $this->verbosity > self::VERBOSITY_MIN ? $url->getAllQueryParams() : json_encode($url->getAllQueryParams());
     }
 }

--- a/src/Middleware/ExceptionMiddleware.php
+++ b/src/Middleware/ExceptionMiddleware.php
@@ -264,16 +264,13 @@ class ExceptionMiddleware implements MiddlewareInterface
             'http_status' => $response->getStatusCode(),
             'env'         => $env,
             'message'     => $e->getMessage(),
-            'source'      => [
-                'file' => $e->getFile(),
-                'line' => $e->getLine(),
-            ],
+            'source'      => sprintf('%s:%s'. $e->getFile(), $e->getLine()),
             'trace'       => $e->getTrace(),
             'url'         => [
                 'raw'   => $currentUrl->__toString(),
                 'host'  => $currentUrl->getHost(),
                 'path'  => $currentUrl->getPath(),
-                'query' => $currentUrl->getAllQueryParams(),
+                'query' => json_encode($currentUrl->getAllQueryParams()),
             ],
             'timestamp'   => (new Moment())->format(),
         ];
@@ -286,7 +283,7 @@ class ExceptionMiddleware implements MiddlewareInterface
                 'raw'   => $refererUrl->__toString(),
                 'host'  => $refererUrl->getHost(),
                 'path'  => $refererUrl->getPath(),
-                'query' => $refererUrl->getAllQueryParams(),
+                'query' => json_encode($refererUrl->getAllQueryParams()),
             ];
         }
 

--- a/src/Middleware/ExceptionMiddleware.php
+++ b/src/Middleware/ExceptionMiddleware.php
@@ -18,6 +18,8 @@ use Zend\Diactoros\Response;
 class ExceptionMiddleware implements MiddlewareInterface
 {
     const DEFAULT_HTTP_STATUS = 500;
+    const VERBOSITY_MIN = 0;
+    const VERBOSITY_MAX = 1;
 
     /**
      * @var HandlerInterface
@@ -33,10 +35,15 @@ class ExceptionMiddleware implements MiddlewareInterface
     protected $errorRedirectUrl;
 
     /**
+     * @var int
+     */
+    protected $verbosity;
+
+    /**
      * @param HandlerInterface $handler
      * @param bool $isProduction
      */
-    public function __construct(?HandlerInterface $handler = null, bool $isProduction = false)
+    public function __construct(?HandlerInterface $handler = null, bool $isProduction = false, int $verbosity = self::VERBOSITY_MIN)
     {
         if (!$handler)
         {
@@ -44,7 +51,8 @@ class ExceptionMiddleware implements MiddlewareInterface
         }
 
         $this->isProduction = $isProduction;
-        $this->handler = $handler;
+        $this->handler      = $handler;
+        $this->verbosity    = $verbosity;
     }
 
     /**
@@ -270,7 +278,9 @@ class ExceptionMiddleware implements MiddlewareInterface
                 'raw'   => $currentUrl->__toString(),
                 'host'  => $currentUrl->getHost(),
                 'path'  => $currentUrl->getPath(),
-                'query' => json_encode($currentUrl->getAllQueryParams()),
+                'query' => $this->verbosity > self::VERBOSITY_MIN
+                        ? json_encode($currentUrl->getAllQueryParams())
+                        : $currentUrl->getAllQueryParams()
             ],
             'timestamp'   => (new Moment())->format(),
         ];
@@ -283,7 +293,9 @@ class ExceptionMiddleware implements MiddlewareInterface
                 'raw'   => $refererUrl->__toString(),
                 'host'  => $refererUrl->getHost(),
                 'path'  => $refererUrl->getPath(),
-                'query' => json_encode($refererUrl->getAllQueryParams()),
+                'query' => $this->verbosity > self::VERBOSITY_MIN
+                        ? json_encode($refererUrl->getAllQueryParams())
+                        : $refererUrl->getAllQueryParams(),
             ];
         }
 


### PR DESCRIPTION
Added constructor parameter and property to control, how URL params will be reported - as a JSON string or as plain array. Top-level `json_encode` will treat JSON as a string and escape it as such, while plain array will be a part of JSON that's being reported to log and recognized by e.g. ES as a subset of fields that need to make it to the index.